### PR TITLE
Neue SEO-Landingpages: n8n-Agentur und KI‑Beratung Mittelstand

### DIFF
--- a/src/pages/ki-beratung-mittelstand.astro
+++ b/src/pages/ki-beratung-mittelstand.astro
@@ -1,0 +1,129 @@
+---
+import SeoLandingPageTemplate from "../components/SeoLandingPageTemplate.astro";
+
+const faqs = [
+  {
+    question: "Was umfasst KI Beratung für den Mittelstand bei codariq?",
+    answer:
+      "Wir prüfen Prozesse, Datenquellen, Risiken und wirtschaftliche Priorität. Danach entsteht kein Foliensatz, sondern ein klarer Pilotplan für einen begrenzten KI-Agenten oder Workflow mit Freigaben und Betriebskonzept.",
+    category: "Leistung",
+  },
+  {
+    question: "Startet ihr mit Strategie oder direkt mit Umsetzung?",
+    answer:
+      "Wir verbinden beides: erst ein kurzer KI-Check, dann ein kleiner produktionsnaher Pilot. So entsteht eine KI-Roadmap aus echten Abläufen statt aus abstrakten Tool-Trends.",
+    category: "Vorgehen",
+  },
+  {
+    question: "Für welche Unternehmen ist die KI Beratung geeignet?",
+    answer:
+      "Für mittelständische Unternehmen und kleine Teams, die bereits viele manuelle Übergaben in E-Mail, CRM, Dokumenten, Support oder Reporting haben und KI kontrolliert in bestehende Systeme integrieren wollen.",
+    category: "Zielgruppe",
+  },
+  {
+    question: "Wie berücksichtigt ihr Datenschutz und EU AI Act?",
+    answer:
+      "Wir planen Datenminimierung, Rollen, Zugriffskonzepte, Speicherorte, Auftragsverarbeitung, Protokolle und menschliche Freigaben früh mit. Rechtliche Prüfung ersetzen wir nicht, aber wir bauen die technische Grundlage für prüfbare KI-Nutzung.",
+    category: "Compliance",
+  },
+];
+---
+
+<SeoLandingPageTemplate
+  title="KI Beratung Mittelstand: Roadmap, Agenten und Prozessintegration | codariq"
+  description="KI Beratung für den Mittelstand: Codariq identifiziert geeignete Prozesse, baut kontrollierbare KI-Agenten und integriert KI in CRM, E-Mail, Dokumente und Backoffice."
+  keywords="KI Beratung Mittelstand, KI Beratung KMU, KI Strategie Mittelstand, KI Roadmap Mittelstand, KI Einführung Mittelstand, KI Agenten Beratung, KI Prozessberatung, KI Automatisierung Mittelstand, KI Integration Mittelstand, DSGVO KI Beratung"
+  breadcrumbName="KI Beratung Mittelstand"
+  breadcrumbUrl="https://codariq.de/ki-beratung-mittelstand"
+  heroTitle="KI Beratung für den Mittelstand, die in Umsetzung endet."
+  heroSubtitle="Wir finden die Prozesse, in denen KI wirklich Arbeit spart, und bauen daraus kontrollierbare Agenten mit Datenwegen, Freigaben, Logs und klarer Betriebsverantwortung."
+  primaryCTA="KI-Potenzial prüfen"
+  secondaryCTA="Agent Readiness starten"
+  secondaryCTALink="/agent-readiness"
+  introEyebrow="KI Strategie und Prozessberatung"
+  introTitle="Erst der Engpass, dann der Agent"
+  introText="Viele Mittelständler wissen, dass KI relevant wird, aber nicht welcher Ablauf zuerst dran ist. Unsere Beratung sortiert Use Cases nach Nutzen, Machbarkeit, Risiko und Integrationsaufwand."
+  cards={[
+    {
+      title: "Prozesse priorisieren",
+      text: "Wir suchen Routinearbeit mit hohem Volumen: E-Mail, CRM, Dokumente, Support, Reporting, Angebots- oder Rechnungsprozesse.",
+    },
+    {
+      title: "Risiken begrenzen",
+      text: "Sensible Daten, Entscheidungen und externe Aktionen bekommen klare Stopps, menschliche Freigaben und nachvollziehbare Protokolle.",
+    },
+    {
+      title: "Pilot statt Großprojekt",
+      text: "Der erste KI-Agent muss klein genug sein, um schnell zu lernen, und relevant genug, um im Alltag spürbar zu entlasten.",
+    },
+  ]}
+  processEyebrow="KI Roadmap für KMU"
+  processTitle="Aus Beratung wird ein belastbarer Umsetzungsplan."
+  processText="Unsere KI Beratung endet nicht bei Empfehlungen. Wir übersetzen die Roadmap in einen ersten kontrollierten Workflow oder Agenten, der mit echten Fällen getestet werden kann."
+  steps={[
+    {
+      title: "KI-Check durchführen",
+      text: "Wir erfassen Ziele, wiederkehrende Aufgaben, Systeme, Datenqualität, Entscheidungsrisiken und aktuelle Tool-Landschaft.",
+      items: [
+        "Use Cases sammeln und clustern",
+        "Aufwand, Nutzen und Datenschutz grob bewerten",
+        "Sofort ungeeignete Ideen aussortieren",
+      ],
+    },
+    {
+      title: "Roadmap und Pilot festlegen",
+      text: "Der stärkste Use Case bekommt ein klares Zielbild: Welche Daten werden gelesen, was bereitet die KI vor und wo bleibt der Mensch verantwortlich?",
+      items: [
+        "führende Systeme und Schnittstellen definieren",
+        "Erfolgskriterien vor dem Bau festlegen",
+        "Betrieb, Support und Verantwortliche planen",
+      ],
+    },
+    {
+      title: "KI-Agent kontrolliert integrieren",
+      text: "Wir bauen den ersten Ablauf, testen ihn mit realistischen Fällen und erweitern erst, wenn Qualität, Akzeptanz und Nutzen stimmen.",
+      items: [
+        "Human-in-the-loop für kritische Schritte",
+        "Logs für Qualität und Fehleranalyse",
+        "Ausbaupfad für weitere Prozesse dokumentieren",
+      ],
+    },
+  ]}
+  proofTitle="Gute KI Beratung macht Entscheidungen leichter."
+  proofText="Am Ende solltest du wissen, welcher KI-Use-Case zuerst kommt, warum er wirtschaftlich sinnvoll ist, welche Risiken begrenzt werden und wie der Pilot technisch betrieben wird."
+  proofItems={[
+    {
+      title: "Klare Priorität",
+      text: "Nicht zehn Ideen gleichzeitig, sondern ein Prozess mit messbarem Nutzen und realistischen Daten.",
+    },
+    {
+      title: "Prüfbare Architektur",
+      text: "Datenflüsse, Rollen, Freigaben und Logs sind geplant, bevor KI produktiv arbeitet.",
+    },
+    {
+      title: "Umsetzbarer Start",
+      text: "Die Roadmap führt direkt in einen Pilot, der bestehende Tools nutzt statt neue Komplexität aufzubauen.",
+    },
+  ]}
+  linksTitle="Vertiefende Seiten für die KI Beratung"
+  links={[
+    {
+      href: "/ki-integration-prozesse",
+      label: "Integration",
+      text: "Für Unternehmen, die KI direkt in bestehende Prozesse und Systeme integrieren wollen.",
+    },
+    {
+      href: "/ki-agenten-kmu",
+      label: "Agenten",
+      text: "Für KMU, die kontrollierbare KI-Agenten für Postfach, Wissen, Backoffice oder Reporting planen.",
+    },
+    {
+      href: "/dsgvo-ki-agenten",
+      label: "Compliance",
+      text: "Für Teams, die Datenschutz, Freigaben und prüfbare Datenwege früh mitdenken wollen.",
+    },
+  ]}
+  faqs={faqs}
+  finalTitle="Lass uns deine KI-Roadmap auf einen ersten Pilot herunterbrechen."
+  finalDescription="Wir prüfen, welcher Prozess für KI Beratung und Umsetzung jetzt den größten Hebel hat - inklusive Datenquellen, Risiko, Freigaben und Betriebsaufwand."
+/>

--- a/src/pages/n8n-agentur.astro
+++ b/src/pages/n8n-agentur.astro
@@ -1,0 +1,129 @@
+---
+import SeoLandingPageTemplate from "../components/SeoLandingPageTemplate.astro";
+
+const faqs = [
+  {
+    question: "Was macht eine n8n Agentur anders als eine klassische IT-Agentur?",
+    answer:
+      "Eine n8n Agentur startet nicht mit einer großen Individualsoftware, sondern mit klar begrenzten Workflows zwischen bestehenden Tools. Wichtig sind Datenquellen, Berechtigungen, Fehlerfälle, Logs und Freigaben, damit Automatisierung im Alltag kontrollierbar bleibt.",
+    category: "Grundlagen",
+  },
+  {
+    question: "Kann n8n auch KI-Agenten steuern?",
+    answer:
+      "Ja, n8n eignet sich als Orchestrierungsschicht für KI-Schritte, Tool-Aufrufe und Freigaben. Für echte Agentenarbeit definieren wir jedoch genau, welche Daten gelesen werden, welche Aktionen erlaubt sind und wann ein Mensch entscheiden muss.",
+    category: "KI-Agenten",
+  },
+  {
+    question: "Welche n8n Workflows lohnen sich zuerst?",
+    answer:
+      "Gute Einstiege sind E-Mail-Triage, Lead-Follow-up, CRM-Datenpflege, Dokumentenprüfung, Rechnungs- oder Angebotsvorbereitung und regelmäßige Reports. Sie haben meist wiederholbares Volumen und klar sichtbare manuelle Nacharbeit.",
+    category: "Use Cases",
+  },
+  {
+    question: "Wie verhindert ihr Tool-Chaos bei n8n Automatisierung?",
+    answer:
+      "Wir legen ein führendes System fest, dokumentieren Datenflüsse, trennen Test- und Produktivlogik und bauen Stopps für Sonderfälle ein. Dadurch bleibt n8n eine kontrollierte Automatisierungsebene statt einer Schattenplattform.",
+    category: "Betrieb",
+  },
+];
+---
+
+<SeoLandingPageTemplate
+  title="n8n Agentur: Workflow-Automatisierung mit KI und Freigaben | codariq"
+  description="Codariq ist deine n8n Agentur für kontrollierbare Workflow-Automatisierung: KI-Agenten, CRM, E-Mail, Dokumente, Freigaben, Logs und DSGVO-orientierte Datenflüsse."
+  keywords="n8n Agentur, n8n Beratung, n8n Automatisierung, n8n Workflow Automatisierung, n8n KI Agent, n8n Agentur Deutschland, n8n CRM Automatisierung, n8n DSGVO, KI Workflow Automatisierung, Agentic AI n8n"
+  breadcrumbName="n8n Agentur"
+  breadcrumbUrl="https://codariq.de/n8n-agentur"
+  heroTitle="n8n Agentur für Workflows, die echte Arbeit abnehmen."
+  heroSubtitle="Wir bauen n8n-Automatisierungen mit KI-Schritten, Freigaben und sauberen Datenwegen: von E-Mail und CRM bis Dokumentenprüfung, Reporting und Backoffice."
+  primaryCTA="n8n Workflow prüfen"
+  secondaryCTA="Agent Readiness testen"
+  secondaryCTALink="/agent-readiness"
+  introEyebrow="n8n Beratung und Umsetzung"
+  introTitle="Automatisierung ohne neue Schattenplattform"
+  introText="n8n ist stark, wenn es bestehende Systeme verbindet und Routinearbeit vorbereitet. Entscheidend ist nicht die Zahl der Nodes, sondern ob der Ablauf stabil, nachvollziehbar und für dein Team freigabefähig bleibt."
+  cards={[
+    {
+      title: "Workflow statt Tool-Sammlung",
+      text: "Wir starten beim konkreten Ablauf: Auslöser, Datenquellen, Zielsystem, Fehlerfälle und die Stellen, an denen ein Mensch entscheiden muss.",
+    },
+    {
+      title: "KI-Agenten mit Grenzen",
+      text: "KI-Schritte dürfen klassifizieren, zusammenfassen, vorbereiten oder prüfen. Kritische Aktionen laufen über Freigaben, Rollen und Protokolle.",
+    },
+    {
+      title: "Betrieb von Anfang an",
+      text: "Produktive n8n Workflows brauchen Tests, Monitoring, Versionslogik und klare Zuständigkeiten. Genau das planen wir vor dem Go-live ein.",
+    },
+  ]}
+  processEyebrow="Von Idee zu produktivem Workflow"
+  processTitle="So wird n8n vom Experiment zum verlässlichen Agenten-Setup."
+  processText="Wir bauen zuerst einen kleinen, wirtschaftlich sinnvollen Workflow. Danach entscheiden wir anhand echter Fälle, ob weitere Systeme, Agentenrollen oder ein größerer Automatisierungsstack nötig sind."
+  steps={[
+    {
+      title: "Use Case und ROI eingrenzen",
+      text: "Wir wählen einen wiederkehrenden Ablauf mit messbarer Nacharbeit und legen fest, was automatisiert, vorbereitet oder bewusst manuell bleiben soll.",
+      items: [
+        "Volumen, Zeitverlust und Fehlerkosten grob schätzen",
+        "führendes System und Datenquellen festlegen",
+        "Freigabepunkte und Sonderfälle markieren",
+      ],
+    },
+    {
+      title: "n8n Workflow sicher aufbauen",
+      text: "Der Workflow entsteht mit klarer Trennung von Triggern, Datenaufbereitung, KI-Schritten, Aktionen, Logs und Eskalationen.",
+      items: [
+        "Credentials und Berechtigungen begrenzen",
+        "Testfälle mit echten Beispielen prüfen",
+        "Fehlerpfade und Benachrichtigungen einbauen",
+      ],
+    },
+    {
+      title: "Agentenlogik kontrolliert erweitern",
+      text: "Wenn der Basisablauf sitzt, ergänzen wir KI-Agenten für Kontext, Priorisierung, Entwürfe oder Recherche - immer mit definierten Grenzen.",
+      items: [
+        "Prompts, Tools und Datenzugriffe versionieren",
+        "Human-in-the-loop für kritische Aktionen",
+        "Ausbau nach Nutzungsdaten statt nach Hype",
+      ],
+    },
+  ]}
+  proofTitle="Ein guter n8n Workflow ist nicht spektakulär. Er läuft einfach sauber."
+  proofText="Der Mehrwert zeigt sich daran, dass weniger kopiert, sortiert, nachgefragt und manuell nachgetragen wird. Dafür braucht n8n klare Architektur statt immer neuer Einzelautomationen."
+  proofItems={[
+    {
+      title: "CRM bleibt führend",
+      text: "Leads, Kontakte und Aufgaben werden vorbereitet, aber nicht in parallelen Listen verstreut.",
+    },
+    {
+      title: "Freigaben bleiben sichtbar",
+      text: "Antworten, Angebotsdaten oder Dokumentenentscheidungen landen bei der richtigen Person, bevor etwas ausgelöst wird.",
+    },
+    {
+      title: "Logs schaffen Vertrauen",
+      text: "Jeder wichtige Schritt ist nachvollziehbar: Eingangsdaten, KI-Ergebnis, Aktion und Abbruchgrund.",
+    },
+  ]}
+  linksTitle="Passende nächste Schritte"
+  links={[
+    {
+      href: "/crm-und-ki-integration",
+      label: "CRM",
+      text: "Wenn dein n8n Workflow Leads, Follow-ups oder Kundendaten mit CRM und E-Mail verbinden soll.",
+    },
+    {
+      href: "/ki-integration-prozesse",
+      label: "Prozesse",
+      text: "Wenn du zuerst klären willst, welcher Prozess sich für KI-Integration wirklich eignet.",
+    },
+    {
+      href: "/blog/ki-agenten-roi-berechnen",
+      label: "ROI",
+      text: "Wenn du mehrere Automatisierungsideen hast und die Reihenfolge wirtschaftlich priorisieren willst.",
+    },
+  ]}
+  faqs={faqs}
+  finalTitle="Lass uns deinen ersten n8n Workflow sauber eingrenzen."
+  finalDescription="Wir prüfen, ob n8n für deinen Ablauf reicht, wo KI sinnvoll ist und welche Freigaben, Logs und Datenwege vor dem Start geklärt werden müssen."
+/>


### PR DESCRIPTION
### Motivation
- Zwei neue kommerzielle Einstiegsseiten sollen gezielte Suchintentionen abdecken, ohne bestehende Blogs oder Landingpages zu ändern. 
- Ziel ist, Traffic für Keywords rund um `n8n`-Agenturen und „KI Beratung Mittelstand“ abzuholen und Codariq als praxisnahe Umsetzer zu positionieren.

### Description
- Neue Dateien `src/pages/n8n-agentur.astro` und `src/pages/ki-beratung-mittelstand.astro` wurden hinzugefügt und nutzen die vorhandene `SeoLandingPageTemplate`-Komponente. 
- Beide Seiten enthalten Title/Description/`keywords`, strukturierte Inhalte (Hero, Schritte, Proof, Links, FAQs) und zielgerichtete Keyword-Sets wie `n8n Agentur`, `n8n Beratung`, `n8n Workflow Automatisierung`, `KI Beratung Mittelstand`, `KI Roadmap Mittelstand` und `DSGVO KI Beratung`. 
- Bestehende Blog- und Landingseiten wurden nicht verändert. 
- Dateien sind formatiert und in das statische Site-Build integriert (Sitemap/Build-Config nutzt bereits ähnliche landing‑pages logic).

### Testing
- Formatprüfung mit `npm run format:check -- src/pages/n8n-agentur.astro src/pages/ki-beratung-mittelstand.astro` wurde erfolgreich ausgeführt. 
- Statischer Build mit `npm run build` lief erfolgreich und erzeugte die neuen Routen (`/n8n-agentur` und `/ki-beratung-mittelstand`) im `dist`-Output. 
- Unittests mit `npm run test:run` (Vitest) wurden ausgeführt und alle Tests sind grün. 
- Ein visueller Screenshot-Versuch mit Playwright schlug fehl, da die Playwright-Browser nicht installiert waren und `npx playwright install chromium` im CI-Umfeld mit einem `403 Forbidden` vom CDN fehlschlug.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a26cb308832d91862e2e2d71c805)